### PR TITLE
Follow the new API and apply other recommendations

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -2,12 +2,12 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/url"
 	"os"
-	
+
 	"github.com/skratchdot/open-golang/open"
 	"github.com/tidwall/gjson"
 	"golang.org/x/term"
@@ -53,7 +53,7 @@ func getResp(param Param) ([]Result, error) {
 
 	defer resp.Body.Close()
 
-	bArray, err := ioutil.ReadAll(resp.Body)
+	bArray, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("レスポンスボディの読み込みに失敗しました: %w", err)
 	}

--- a/utils.go
+++ b/utils.go
@@ -7,8 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"strconv"
-
+	
 	"github.com/skratchdot/open-golang/open"
 	"github.com/tidwall/gjson"
 	"golang.org/x/term"
@@ -29,14 +28,12 @@ type Param struct {
 func newURL(param Param) string {
 	u := &url.URL{
 		Scheme: "https",
-		Host:   "freasearch.org",
+		Host:   "api.freasearch.org",
 		Path:   "search",
 	}
 	q := u.Query()
-	q.Set("format", "json")
 	q.Set("q", param.Query)
-	q.Set("language", param.Language)
-	q.Set("safesearch", strconv.Itoa(param.SafeSearch))
+	q.Set("language", "ja-JP")
 	u.RawQuery = q.Encode()
 
 	return u.String()
@@ -62,7 +59,7 @@ func getResp(param Param) ([]Result, error) {
 	}
 
 	results := gjson.Get(string(bArray), "results")
-
+	
 	ctns := []Result{}
 
 	for _, result := range results.Array() {


### PR DESCRIPTION
- FreaSearch APIのアップデートに追従
- "io/ioutil"が非推奨になったため修正

close #6 